### PR TITLE
Fix overflow for blob sizes using Python2 on SAS

### DIFF
--- a/Python/Storage/README.md
+++ b/Python/Storage/README.md
@@ -31,8 +31,8 @@ or through standard setup.py procedures. As of this script version 0.9.9.0,
 it no longer supports the legacy Azure Python SDK, i.e., `azure` package with
 version < 1.0.0 due to breaking changes in the azure packages.
 
-Program parameters and command-line options can be listed via the -h switch. At
-the minimum, three positional arguments are required: storage account name,
+Program parameters and command-line options can be listed via the `-h` switch.
+At the minimum, three positional arguments are required: storage account name,
 container name, local resource. Additionally, one of the following
 authentication switches must be supplied: `--subscriptionid` with
 `--managementcert`, `--storageaccountkey`, or `--saskey`. It is recommended
@@ -103,6 +103,7 @@ script in a `virtualenv` environment without the `ndg-httpsclient` package.
 Python versions >= 2.7.9 are not affected by this issue.
 
 ###Change Log
+* 0.9.9.1: fix content length > 32bit for blob lists via SAS on Python2
 * 0.9.9.0: update script for compatibility with new Azure Python packages
 * 0.9.8: fix blob endpoint for non-SAS input, add retry on ServerBusy
 * 0.9.7: normalize SAS keys (accept keys with or without ? char prefix)

--- a/Python/Storage/blobxfer.py
+++ b/Python/Storage/blobxfer.py
@@ -111,7 +111,7 @@ except NameError:  # pragma: no cover
 # pylint: enable=W0622,C0103
 
 # global defines
-_SCRIPT_VERSION = '0.9.9.0'
+_SCRIPT_VERSION = '0.9.9.1'
 _DEFAULT_MAX_STORAGEACCOUNT_WORKERS = 64
 _MAX_BLOB_CHUNK_SIZE_BYTES = 4194304
 _MAX_LISTBLOBS_RESULTS = 1000
@@ -172,7 +172,8 @@ class SasBlobList(object):
         Raises:
             Nothing
         """
-        self.next_marker = marker
+        if marker is not None and len(marker) > 0:
+            self.next_marker = marker
 
 
 class SasBlobService(object):
@@ -213,7 +214,7 @@ class SasBlobService(object):
         for blob in blobs.iter('Blob'):
             name = blob.find('Name').text
             props = blob.find('Properties')
-            cl = int(props.find('Content-Length').text)
+            cl = long(props.find('Content-Length').text)
             md5 = props.find('Content-MD5').text
             bt = props.find('BlobType').text
             result.add_blob(name, cl, md5, bt)

--- a/Python/Storage/test/test_blobxfer.py
+++ b/Python/Storage/test/test_blobxfer.py
@@ -133,7 +133,7 @@ def test_sasblobservice_listblobs():
         b'<Delimiter>string-value</Delimiter><Blobs><Blob><Name>blob-name' + \
         b'</Name><Snapshot>date-time-value</Snapshot><Properties>' + \
         b'<Last-Modified>date-time-value</Last-Modified><Etag>etag</Etag>' + \
-        b'<Content-Length>1234</Content-Length><Content-Type>' + \
+        b'<Content-Length>2147483648</Content-Length><Content-Type>' + \
         b'blob-content-type</Content-Type><Content-Encoding />' + \
         b'<Content-Language /><Content-MD5>abc</Content-MD5>' + \
         b'<Cache-Control /><x-ms-blob-sequence-number>sequence-number' + \
@@ -147,8 +147,8 @@ def test_sasblobservice_listblobs():
         b'datetime</CopyCompletionTime><CopyStatusDescription>' + \
         b'error string</CopyStatusDescription></Properties><Metadata>' + \
         b'<Name>value</Name></Metadata></Blob><BlobPrefix><Name>' + \
-        b'blob-prefix</Name></BlobPrefix></Blobs><NextMarker />' + \
-        b'</EnumerationResults>'
+        b'blob-prefix</Name></BlobPrefix></Blobs><NextMarker>nm' + \
+        b'</NextMarker></EnumerationResults>'
 
     with requests_mock.mock() as m:
         m.get('mock://blobepcontainer?saskey', content=content)
@@ -156,10 +156,10 @@ def test_sasblobservice_listblobs():
         result = sbs.list_blobs('container', 'marker')
         assert len(result) == 1
         assert result[0].name == 'blob-name'
-        assert result[0].properties.content_length == 1234
+        assert result[0].properties.content_length == 2147483648
         assert result[0].properties.content_md5 == 'abc'
         assert result[0].properties.blobtype == 'BlockBlob'
-        assert result.next_marker is None
+        assert result.next_marker == 'nm'
 
         m.get('mock://blobepcontainer?saskey', content=b'', status_code=201)
         sbs = blobxfer.SasBlobService('mock://blobep', 'saskey', None)


### PR DESCRIPTION
- Only allow next_marker to be set when set with a valid string