### PR TITLE
Use collection type for collection item prefix

### DIFF
--- a/CSharp/BatchExplorer/Models/ModelBase.cs
+++ b/CSharp/BatchExplorer/Models/ModelBase.cs
@@ -115,13 +115,14 @@ namespace Microsoft.Azure.BatchExplorer.Models
                     else if (typeof (IEnumerable).IsAssignableFrom(propertyType))
                     {
                         IEnumerable enumerable = propertyValue as IEnumerable;
+                        string prefix = CollectionPropertyModel.GetItemDisplayPrefix(enumerable);
                         List<PropertyModel> collectionModel = new List<PropertyModel>();
                         int i = 0;
                         foreach (object enumerableObject in enumerable)
                         {
                             List<PropertyModel> innerPropertyModels = this.ObjectToPropertyModelRecursive(enumerableObject, propertiesToOmit);
-                            
-                            collectionModel.Add(new CollectionPropertyModel("item" + i, innerPropertyModels));
+
+                            collectionModel.Add(new CollectionPropertyModel(prefix + i, innerPropertyModels));
                             i++;
                         }
 

--- a/CSharp/BatchExplorer/Models/PropertyDisplayModel.cs
+++ b/CSharp/BatchExplorer/Models/PropertyDisplayModel.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.BatchExplorer.Models
 
         internal static string GetItemDisplayPrefix(IEnumerable collection)
         {
-            var elementType = ElementType(collection.GetType());
+            Type elementType = ElementType(collection.GetType());
             if (elementType == null)
             {
                 return "item";
@@ -60,14 +60,14 @@ namespace Microsoft.Azure.BatchExplorer.Models
             Debug.Assert(collectionType != null);
             Debug.Assert(typeof(IEnumerable).IsAssignableFrom(collectionType));
 
-            var stis = collectionType.FindInterfaces((m, c) => m.IsConstructedGenericType && m.GetGenericTypeDefinition() == typeof(IEnumerable<>), null);
+            Type[] stronglyTypedInterfaces = collectionType.FindInterfaces((m, c) => m.IsConstructedGenericType && m.GetGenericTypeDefinition() == typeof(IEnumerable<>), null);
 
-            if (stis == null || stis.Length == 0 || stis.Length > 1)
+            if (stronglyTypedInterfaces == null || stronglyTypedInterfaces.Length == 0 || stronglyTypedInterfaces.Length > 1)
             {
                 return null;  // not a strongly typed collection, or a strongly typed collection of more than one thing (yikes)
             }
 
-            return stis[0].GetGenericArguments()[0];
+            return stronglyTypedInterfaces[0].GetGenericArguments()[0];
         }
     }
 }

--- a/CSharp/BatchExplorer/Models/PropertyDisplayModel.cs
+++ b/CSharp/BatchExplorer/Models/PropertyDisplayModel.cs
@@ -3,7 +3,9 @@
 namespace Microsoft.Azure.BatchExplorer.Models
 {
     using System;
+    using System.Collections;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Linq;
     using System.Text;
     using System.Threading.Tasks;
@@ -41,6 +43,31 @@ namespace Microsoft.Azure.BatchExplorer.Models
             : base(propertyName)
         {
             this.Items = items;
+        }
+
+        internal static string GetItemDisplayPrefix(IEnumerable collection)
+        {
+            var elementType = ElementType(collection.GetType());
+            if (elementType == null)
+            {
+                return "item";
+            }
+            return elementType.Name;
+        }
+
+        private static Type ElementType(Type collectionType)
+        {
+            Debug.Assert(collectionType != null);
+            Debug.Assert(typeof(IEnumerable).IsAssignableFrom(collectionType));
+
+            var stis = collectionType.FindInterfaces((m, c) => m.IsConstructedGenericType && m.GetGenericTypeDefinition() == typeof(IEnumerable<>), null);
+
+            if (stis == null || stis.Length == 0 || stis.Length > 1)
+            {
+                return null;  // not a strongly typed collection, or a strongly typed collection of more than one thing (yikes)
+            }
+
+            return stis[0].GetGenericArguments()[0];
         }
     }
 }


### PR DESCRIPTION
For example, when displaying a collection of ResourceFiles, call them ResourceFile1, ResourceFile2, etc. instead of item1, item2, etc.