### PR TITLE
Remove (perfectly valid) spaces from username when generating job ID

### DIFF
--- a/CSharp/Common/GettingStartedCommon.cs
+++ b/CSharp/Common/GettingStartedCommon.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.Batch.Samples.Common
         public static string CreateJobId(string prefix)
         {
             // a job is uniquely identified by its ID so your account name along with a timestamp is added as suffix
-            return string.Format("{0}-{1}-{2}", prefix, Environment.UserName.Replace(" ", ""), DateTime.Now.ToString("yyyyMMdd-HHmmss"));
+            return string.Format("{0}-{1}-{2}", prefix, new string(Environment.UserName.Where(char.IsLetterOrDigit).ToArray()), DateTime.Now.ToString("yyyyMMdd-HHmmss"));
         }
 
         /// <summary>

--- a/CSharp/Common/GettingStartedCommon.cs
+++ b/CSharp/Common/GettingStartedCommon.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.Batch.Samples.Common
         public static string CreateJobId(string prefix)
         {
             // a job is uniquely identified by its ID so your account name along with a timestamp is added as suffix
-            return string.Format("{0}-{1}-{2}", prefix, Environment.GetEnvironmentVariable("USERNAME"), DateTime.Now.ToString("yyyyMMdd-HHmmss"));
+            return string.Format("{0}-{1}-{2}", prefix, Environment.UserName.Replace(" ", ""), DateTime.Now.ToString("yyyyMMdd-HHmmss"));
         }
 
         /// <summary>

--- a/CSharp/GettingStarted/01_HelloWorld/Program.cs
+++ b/CSharp/GettingStarted/01_HelloWorld/Program.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.Batch.Samples.HelloWorld
                 // add a retry policy. The built-in policies are No Retry (default), Linear Retry, and Exponential Retry
                 batchClient.CustomBehaviors.Add(RetryPolicyProvider.LinearRetryProvider(TimeSpan.FromSeconds(10), 3));
 
-                string jobId = string.Format("{0}-{1}-{2}", "HelloWorldJob", Environment.GetEnvironmentVariable("USERNAME"), DateTime.Now.ToString("yyyyMMdd-HHmmss"));
+                string jobId = GettingStartedCommon.CreateJobId("HelloWorldJob");
 
                 try
                 {


### PR DESCRIPTION
If the logged in user has a space in her/his name (I have :)), the samples cannot run. Moreover, they fail with silly "resource not found"-kind-of-errors because they try to delete stuff that wasn't created in the first place.

This commit removes spaces from the user's username in the `GettingStartedCommon.CreateJobId` method + changes the very first GettingStarted sample (01_HelloWorld) to use `GettingStartedCommon.CreateJobId` as the other samples do.