### PR TITLE
Add resource file support to workhorse tasks

### DIFF
--- a/CSharp/BatchExplorer/Models/AddTaskOptions.cs
+++ b/CSharp/BatchExplorer/Models/AddTaskOptions.cs
@@ -1,5 +1,7 @@
 ﻿//Copyright (c) Microsoft Corporation
 
+using System.Collections.Generic;
+
 namespace Microsoft.Azure.BatchExplorer.Models
 {
     public class AddTaskOptions
@@ -9,5 +11,7 @@ namespace Microsoft.Azure.BatchExplorer.Models
         public string CommandLine { get; set; }
 
         public string TaskId { get; set; }
+
+        public List<ResourceFileInfo> ResourceFiles { get; set; }
     }
 }

--- a/CSharp/BatchExplorer/Service/BatchService.cs
+++ b/CSharp/BatchExplorer/Service/BatchService.cs
@@ -299,6 +299,7 @@ namespace Microsoft.Azure.BatchExplorer.Service
         public async Task AddTaskAsync(AddTaskOptions options)
         {
             CloudTask unboundTask = new CloudTask(options.TaskId, options.CommandLine);
+            unboundTask.ResourceFiles = options.ResourceFiles.ConvertAll(f => new ResourceFile(f.BlobSource, f.FilePath));
             await this.Client.JobOperations.AddTaskAsync(options.JobId, unboundTask);
         }
         #endregion

--- a/CSharp/BatchExplorer/ViewModels/AddTaskViewModel.cs
+++ b/CSharp/BatchExplorer/ViewModels/AddTaskViewModel.cs
@@ -1,6 +1,7 @@
 ﻿//Copyright (c) Microsoft Corporation
 
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using GalaSoft.MvvmLight.Messaging;
 using Microsoft.Azure.BatchExplorer.Helpers;
@@ -60,6 +61,21 @@ namespace Microsoft.Azure.BatchExplorer.ViewModels
                 this.FirePropertyChangedEvent("CommandLine");
             }
         }
+
+        private string resourceFiles;
+        public string ResourceFiles
+        {
+            get
+            {
+                return this.resourceFiles;
+            }
+            set
+            {
+                this.resourceFiles = value;
+                this.FirePropertyChangedEvent("ResourceFiles");
+            }
+        }
+
         #endregion
 
         #region Commands
@@ -103,7 +119,8 @@ namespace Microsoft.Azure.BatchExplorer.ViewModels
                     {
                         JobId = this.jobId,
                         CommandLine = this.CommandLine,
-                        TaskId = this.TaskId
+                        TaskId = this.TaskId,
+                        ResourceFiles = ResourceFileStringParser.Parse(this.ResourceFiles).Files.ToList(),
                     };
 
                     await this.batchService.AddTaskAsync(options);
@@ -129,6 +146,13 @@ namespace Microsoft.Azure.BatchExplorer.ViewModels
             if (string.IsNullOrEmpty(this.CommandLine))
             {
                 Messenger.Default.Send<GenericDialogMessage>(new GenericDialogMessage("Invalid values for Command Line"));
+                return false;
+            }
+
+            var resourceFiles = ResourceFileStringParser.Parse(this.ResourceFiles);
+            if (resourceFiles.HasErrors)
+            {
+                Messenger.Default.Send<GenericDialogMessage>(new GenericDialogMessage(String.Join(Environment.NewLine, resourceFiles.Errors)));
                 return false;
             }
 

--- a/CSharp/BatchExplorer/Views/CreateControls/AddTaskControl.xaml
+++ b/CSharp/BatchExplorer/Views/CreateControls/AddTaskControl.xaml
@@ -21,6 +21,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <TextBlock 
@@ -94,9 +95,12 @@
             Grid.Column="1"
             Text="{Binding CommandLine}"/>
         
+        <TextBlock Grid.Row="5" Grid.Column="0" Margin="8,4">Resource Files</TextBlock>
+        <TextBox Grid.Row="5" Grid.Column="1" AcceptsReturn="True" Text="{Binding StartTaskResourceFiles}" ToolTip="List of resource files in format blobSource => filePath, delimited by newlines or semicolons" Margin="0,0,0,2" />
+
         <!-- Buttons -->
         <StackPanel
-            Grid.Row="5"
+            Grid.Row="6"
             Orientation="Horizontal"
             HorizontalAlignment="Right">
             <Button


### PR DESCRIPTION
Job > Add Task isn't of limited use if you can't specify resource files.  This PR allows users to specify resource files on tasks, admittedly with the same awkward syntax as resource files on start tasks.