### PR TITLE
 Add 'Preparing' task state to color converter

### DIFF
--- a/CSharp/BatchExplorer/Converters/TaskStatusColorConverter.cs
+++ b/CSharp/BatchExplorer/Converters/TaskStatusColorConverter.cs
@@ -27,6 +27,8 @@ namespace Microsoft.Azure.BatchExplorer.Converters
                     return new SolidColorBrush(Colors.DarkRed);
                 case TaskState.Active:
                     return new SolidColorBrush(Colors.Orange);
+                case TaskState.Preparing:
+                    return new SolidColorBrush(Colors.LightBlue);
                 case TaskState.Running:
                     return new SolidColorBrush(Colors.Blue);
                 case TaskState.Completed:


### PR DESCRIPTION
Resolving ArgumentOutOfRangeException when selecting the Jobs tab with task(s) in the Preparing state.