### PR TITLE
Fixed UI binding error in Add Task resource files

### DIFF
--- a/CSharp/BatchExplorer/Views/CreateControls/AddTaskControl.xaml
+++ b/CSharp/BatchExplorer/Views/CreateControls/AddTaskControl.xaml
@@ -96,7 +96,7 @@
             Text="{Binding CommandLine}"/>
         
         <TextBlock Grid.Row="5" Grid.Column="0" Margin="8,4">Resource Files</TextBlock>
-        <TextBox Grid.Row="5" Grid.Column="1" AcceptsReturn="True" Text="{Binding StartTaskResourceFiles}" ToolTip="List of resource files in format blobSource => filePath, delimited by newlines or semicolons" Margin="0,0,0,2" />
+        <TextBox Grid.Row="5" Grid.Column="1" AcceptsReturn="True" Text="{Binding ResourceFiles}" ToolTip="List of resource files in format blobSource => filePath, delimited by newlines or semicolons" Margin="0,0,0,2" />
 
         <!-- Buttons -->
         <StackPanel


### PR DESCRIPTION
This fixes a copy-paste error in the Add Task control which meant resource files were not correctly added to workhorse tasks.