### PR TITLE
Added --info and --include flags

### DIFF
--- a/Python/Storage/test/test_blobxfer.py
+++ b/Python/Storage/test/test_blobxfer.py
@@ -488,6 +488,8 @@ def test_main1(
     args.container = 'container'
     args.storageaccountkey = 'saskey'
     args.chunksizebytes = 5
+    args.info = False
+    args.include = None
     args.pageblob = False
     args.autovhd = False
     patched_parseargs.return_value = args
@@ -754,6 +756,8 @@ def test_main2(patched_parseargs, tmpdir):
     args.localresource = lpath
     args.blobep = '.blobep'
     args.timeout = 10
+    args.info = False
+    args.include = None
     args.pageblob = False
     args.autovhd = False
     args.managementep = None


### PR DESCRIPTION
* the info flag prints the properties of the blob specified by
the remoteresource arg
* localresorce is optional now and defaults to current working directory
* use include flag to only include the files that match the passed in
Unix style file pattern
* Fixed failing tests