### PR TITLE
Feature to delete selected jobs and clear all jobs feature

### DIFF
--- a/CSharp/BatchExplorer/Models/JobModel.cs
+++ b/CSharp/BatchExplorer/Models/JobModel.cs
@@ -22,12 +22,23 @@ namespace Microsoft.Azure.BatchExplorer.Models
     public class JobModel : ModelBase
     {
         #region Public properties
-
+               
+        private bool isChecked;
         /// <summary>
         /// Marker for multi selection
         /// </summary>
-        [ChangeTracked(ModelRefreshType.Basic)]
-        public bool IsChecked { get; set; }
+        public bool IsChecked
+        {
+            get
+            {
+                return this.isChecked;
+            }
+            set
+            {
+                this.isChecked = value;
+                this.FirePropertyChangedEvent("IsChecked");
+            }
+        }
 
         /// <summary>
         /// Gets the id of the job
@@ -310,7 +321,7 @@ namespace Microsoft.Azure.BatchExplorer.Models
         /// <summary>
         /// Delete this job
         /// </summary>
-        public async System.Threading.Tasks.Task DeleteAsync()
+        public async System.Threading.Tasks.Task DeleteAsync(bool refresh = true)
         {
             try
             {
@@ -319,7 +330,10 @@ namespace Microsoft.Azure.BatchExplorer.Models
                     asyncTask,
                     new JobOperation(JobOperation.Delete, this.Job.Id)));
                 await asyncTask;
-                Messenger.Default.Send<RefreshMessage>(new RefreshMessage(RefreshTarget.Jobs));
+                if (refresh)
+                {
+                    Messenger.Default.Send<RefreshMessage>(new RefreshMessage(RefreshTarget.Jobs));
+                }
             }
             catch (Exception e)
             {

--- a/CSharp/BatchExplorer/Models/JobModel.cs
+++ b/CSharp/BatchExplorer/Models/JobModel.cs
@@ -22,7 +22,13 @@ namespace Microsoft.Azure.BatchExplorer.Models
     public class JobModel : ModelBase
     {
         #region Public properties
-        
+
+        /// <summary>
+        /// Marker for multi selection
+        /// </summary>
+        [ChangeTracked(ModelRefreshType.Basic)]
+        public bool IsChecked { get; set; }
+
         /// <summary>
         /// Gets the id of the job
         /// </summary>

--- a/CSharp/BatchExplorer/ViewModels/MainViewModel.cs
+++ b/CSharp/BatchExplorer/ViewModels/MainViewModel.cs
@@ -814,7 +814,7 @@ namespace Microsoft.Azure.BatchExplorer.ViewModels
                         {
                             foreach (var job in this.jobs)
                             {
-                                job.IsChecked = bool.Parse(o.ToString());
+                                job.IsChecked = bool.Parse(commandArg.ToString());
                             }
                         }                      
                     });

--- a/CSharp/BatchExplorer/ViewModels/MainViewModel.cs
+++ b/CSharp/BatchExplorer/ViewModels/MainViewModel.cs
@@ -740,7 +740,7 @@ namespace Microsoft.Azure.BatchExplorer.ViewModels
             get
             {
                 return new CommandBase( 
-                    async (arg) =>
+                    async (commandArg) =>
                     {                        
                         if (this.jobs.Any(a => a.IsChecked))
                         {
@@ -808,7 +808,7 @@ namespace Microsoft.Azure.BatchExplorer.ViewModels
             get
             {
                 return new CommandBase(
-                    (o) =>
+                    (commandArg) =>
                     {
                         if (this.jobs != null && this.jobs.Count > 0)
                         {

--- a/CSharp/BatchExplorer/ViewModels/MainViewModel.cs
+++ b/CSharp/BatchExplorer/ViewModels/MainViewModel.cs
@@ -733,6 +733,32 @@ namespace Microsoft.Azure.BatchExplorer.ViewModels
         }
 
         /// <summary>
+        /// Delete selected jobs
+        /// </summary>
+        public CommandBase DeleteSelectedJobs
+        {
+            get
+            {
+                return new CommandBase(
+                    (o) =>
+                    {
+                        foreach (var job in this.jobs)
+                        {
+                            if (job.IsChecked || (o != null && o.ToString() == "All"))
+                            {
+                                System.Threading.Tasks.Task asyncTask = job.DeleteAsync();
+                                AsyncOperationTracker.Instance.AddTrackedOperation(new AsyncOperationModel(
+                                    asyncTask,
+                                    new JobOperation(JobOperation.Delete, job.Id)));
+                            }
+                        }
+
+                        Messenger.Default.Send<RefreshMessage>(new RefreshMessage(RefreshTarget.Jobs));
+                    });
+            }
+        }
+
+        /// <summary>
         /// Refresh all pools
         /// </summary>
         public CommandBase RefreshPools

--- a/CSharp/BatchExplorer/Views/MainView.xaml
+++ b/CSharp/BatchExplorer/Views/MainView.xaml
@@ -687,19 +687,7 @@
                                         <TextBlock HorizontalAlignment="Center" Text="Delete" FontSize="12" Foreground="Black" />
                                     </StackPanel>
                                 </Button.Content>
-                            </Button>
-                            <Button
-                                Margin="4"
-                                Width="48"
-                                Command="{Binding DeleteSelectedJobs}" CommandParameter="All"
-                                IsEnabled="{Binding IsAccountConnected, NotifyOnSourceUpdated=True}">
-                                <Button.Content>
-                                    <StackPanel>
-                                        <Image Source="../Images/cancel.png" Height="36"/>
-                                        <TextBlock HorizontalAlignment="Center" Text="Clear" FontSize="12" Foreground="Black" />
-                                    </StackPanel>
-                                </Button.Content>
-                            </Button>
+                            </Button>                            
                         </StackPanel>
                         <DataGrid
                             Grid.Row="1"
@@ -745,9 +733,12 @@
                             </DataGrid.ContextMenu>
                             <DataGrid.Columns>
                                 <DataGridTemplateColumn>
+                                    <DataGridTemplateColumn.Header>
+                                        <CheckBox x:Name="selectAllJob" Command="{Binding DataContext.SelectAllJobs, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type DataGrid}}}" CommandParameter="{Binding IsChecked, ElementName=selectAllJob}"/>
+                                    </DataGridTemplateColumn.Header>
                                     <DataGridTemplateColumn.CellTemplate>
                                         <DataTemplate>
-                                            <CheckBox IsChecked="{Binding IsChecked, UpdateSourceTrigger=PropertyChanged}" />
+                                            <CheckBox IsChecked="{Binding IsChecked, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" HorizontalAlignment="Center" />
                                         </DataTemplate>
                                     </DataGridTemplateColumn.CellTemplate>
                                 </DataGridTemplateColumn>

--- a/CSharp/BatchExplorer/Views/MainView.xaml
+++ b/CSharp/BatchExplorer/Views/MainView.xaml
@@ -676,6 +676,30 @@
                                     </StackPanel>
                                 </Button.Content>
                             </Button>
+                            <Button
+                                Margin="4"
+                                Width="48"
+                                Command="{Binding DeleteSelectedJobs}"
+                                IsEnabled="{Binding IsAccountConnected, NotifyOnSourceUpdated=True}">
+                                <Button.Content>
+                                    <StackPanel>
+                                        <Image Source="../Images/delete.png" Height="36"/>
+                                        <TextBlock HorizontalAlignment="Center" Text="Delete" FontSize="12" Foreground="Black" />
+                                    </StackPanel>
+                                </Button.Content>
+                            </Button>
+                            <Button
+                                Margin="4"
+                                Width="48"
+                                Command="{Binding DeleteSelectedJobs}" CommandParameter="All"
+                                IsEnabled="{Binding IsAccountConnected, NotifyOnSourceUpdated=True}">
+                                <Button.Content>
+                                    <StackPanel>
+                                        <Image Source="../Images/cancel.png" Height="36"/>
+                                        <TextBlock HorizontalAlignment="Center" Text="Clear" FontSize="12" Foreground="Black" />
+                                    </StackPanel>
+                                </Button.Content>
+                            </Button>
                         </StackPanel>
                         <DataGrid
                             Grid.Row="1"
@@ -720,6 +744,13 @@
                                 </ContextMenu>
                             </DataGrid.ContextMenu>
                             <DataGrid.Columns>
+                                <DataGridTemplateColumn>
+                                    <DataGridTemplateColumn.CellTemplate>
+                                        <DataTemplate>
+                                            <CheckBox IsChecked="{Binding IsChecked, UpdateSourceTrigger=PropertyChanged}" />
+                                        </DataTemplate>
+                                    </DataGridTemplateColumn.CellTemplate>
+                                </DataGridTemplateColumn>
                                 <DataGridTextColumn Header="Id" Binding="{Binding Id}"/>
                                 <DataGridTextColumn Header="Display Name" Binding="{Binding DisplayName}"/>
                                 <DataGridTextColumn Header="State" Binding="{Binding State}">


### PR DESCRIPTION
The tool become very slow once job number grows as t tries to fetch all the jobs. There is no way to delete multiple jobs at a time. This feature will enable to delete multiple jobs as well as clear all jobs from history.