### PR TITLE
Fix for metrics library consumer sample error if no jobs in account

### DIFF
--- a/CSharp/BatchMetrics/BatchMetricsUsageSample/Program.cs
+++ b/CSharp/BatchMetrics/BatchMetricsUsageSample/Program.cs
@@ -104,6 +104,11 @@ namespace Microsoft.Azure.Batch.Samples.BatchMetricsUsageSample
                 return error.GetType().Name + ": " + error.Message;
             }
 
+            if (!metrics.JobIds.Any())
+            {
+                return "No jobs in account";
+            }
+
             var jobIdFormatLength = metrics.JobIds.Max(id => id.Length);
             var jobInfos = metrics.JobIds.Select(id => FormatJobMetrics(id, metrics.GetMetrics(id), jobIdFormatLength));
             return String.Join(Environment.NewLine, jobInfos);


### PR DESCRIPTION
The sample program for consuming the metrics library had an error where the MetricsUpdated handler would throw if there were no jobs in the account (before the sample program started submitting them). This PR fixes that error and provides an informative message instead.