### PR TITLE
Fix for Batch Explorer Add Account and Edit Account not working in release builds

### DIFF
--- a/CSharp/BatchExplorer/Messages/ConfirmAccountAddMessage.cs
+++ b/CSharp/BatchExplorer/Messages/ConfirmAccountAddMessage.cs
@@ -1,6 +1,7 @@
 ﻿//Copyright (c) Microsoft Corporation
 
 using Microsoft.Azure.BatchExplorer.Models;
+using Microsoft.Azure.BatchExplorer.PluginInterfaces.AccountPlugin;
 
 namespace Microsoft.Azure.BatchExplorer.Messages
 {
@@ -9,6 +10,7 @@ namespace Microsoft.Azure.BatchExplorer.Messages
     /// </summary>
     public class ConfirmAccountAddMessage
     {
+        public IAccountManager AccountManager { get; set; }
         public Account AccountToAdd { get; set; }
     }
 }

--- a/CSharp/BatchExplorer/Messages/ConfirmAccountEditMessage.cs
+++ b/CSharp/BatchExplorer/Messages/ConfirmAccountEditMessage.cs
@@ -1,6 +1,7 @@
 ﻿//Copyright (c) Microsoft Corporation
 
 using Microsoft.Azure.BatchExplorer.Models;
+using Microsoft.Azure.BatchExplorer.PluginInterfaces.AccountPlugin;
 
 namespace Microsoft.Azure.BatchExplorer.Messages
 {
@@ -9,6 +10,7 @@ namespace Microsoft.Azure.BatchExplorer.Messages
     /// </summary>
     public class ConfirmAccountEditMessage
     {
+        public IAccountManager AccountManager { get; set; }
         public Account AccountToEdit { get; set; }
     }
 }

--- a/CSharp/BatchExplorer/ViewModels/AccountDialogViewModel.cs
+++ b/CSharp/BatchExplorer/ViewModels/AccountDialogViewModel.cs
@@ -12,12 +12,13 @@ namespace Microsoft.Azure.BatchExplorer.ViewModels
     public class AccountDialogViewModel : EntityBase
     {
         private readonly AccountManagementOperation accountOperation;
+        private readonly IAccountManager accountManager;
 
         /// <summary>
         /// Use this constructor when creating a dialog that will be used on a new account
         /// </summary>
-        public AccountDialogViewModel(IAccountOperationFactory factory)
-            : this(null, factory)
+        public AccountDialogViewModel(IAccountManager accountManager, IAccountOperationFactory factory)
+            : this(null, accountManager, factory)
         { }
 
         /// <summary>
@@ -25,8 +26,10 @@ namespace Microsoft.Azure.BatchExplorer.ViewModels
         /// </summary>
         /// <param name="account">the existing account to be edited</param>
         /// <param name="factory"></param>
-        public AccountDialogViewModel(Account account, IAccountOperationFactory factory)
+        public AccountDialogViewModel(Account account, IAccountManager accountManager, IAccountOperationFactory factory)
         {
+            this.accountManager = accountManager;
+
             if (account != null)
             {
                 this.accountOperation = factory.CreateEditAccountOperation(account);
@@ -57,12 +60,12 @@ namespace Microsoft.Azure.BatchExplorer.ViewModels
 
         private void ConfirmNew(object o)
         {
-            Messenger.Default.Send(new ConfirmAccountAddMessage() { AccountToAdd = this.accountOperation.Complete() });
+            Messenger.Default.Send(new ConfirmAccountAddMessage() { AccountManager = this.accountManager, AccountToAdd = this.accountOperation.Complete() });
         }
 
         private void ConfirmEdit(object o)
         {
-            Messenger.Default.Send(new ConfirmAccountEditMessage() { AccountToEdit = this.accountOperation.Complete() });
+            Messenger.Default.Send(new ConfirmAccountEditMessage() { AccountManager = this.accountManager, AccountToEdit = this.accountOperation.Complete() });
         }
 
         private void CancelNew(object o)


### PR DESCRIPTION
Fixes #181.  MVVM Light message handlers that are implemented as lambdas that close over local variables became eligible for GC, because they are compiled as methods of an anonymous type, and MVVM Light held only a weak reference to the instance of that type.  (This didn't happen in debug builds because the runtime artificially kept the instance alive until the end of the scope.)  This PR makes the affected handlers not close over local variables, so they can be compiled as instance methods on MainViewModel, which is not eligible for GC.