### PR TITLE
Add MPI project to multi-instance sample .sln

### DIFF
--- a/CSharp/.gitignore
+++ b/CSharp/.gitignore
@@ -74,6 +74,7 @@ _Chutzpah*
 ipch/
 *.aps
 *.ncb
+*.opendb
 *.opensdf
 *.sdf
 *.cachefile

--- a/CSharp/ArticleProjects/MultiInstanceTasks/MPIHelloWorld/MPIHelloWorld.vcxproj
+++ b/CSharp/ArticleProjects/MultiInstanceTasks/MPIHelloWorld/MPIHelloWorld.vcxproj
@@ -1,10 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="Debug|x64">
-      <Configuration>Debug</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -17,12 +13,6 @@
     <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
@@ -39,28 +29,9 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
-    <LinkIncremental>true</LinkIncremental>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
-      <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(MSMPI_INC);$(MSMPI_INC)\x64</AdditionalIncludeDirectories>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(MSMPI_LIB64)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>msmpi.lib;%(AdditionalDependencies)</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
@@ -70,14 +41,14 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(MSMPI_INC);$(MSMPI_INC)\x64</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)\packages\MSMPISDK.7.1.12437.25\Include;$(SolutionDir)\packages\MSMPISDK.7.1.12437.25\Include\x64</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(MSMPI_LIB64)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(SolutionDir)\packages\MSMPISDK.7.1.12437.25\Lib\x64</AdditionalLibraryDirectories>
       <AdditionalDependencies>msmpi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
@@ -90,6 +61,9 @@
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/CSharp/ArticleProjects/MultiInstanceTasks/MPIHelloWorld/packages.config
+++ b/CSharp/ArticleProjects/MultiInstanceTasks/MPIHelloWorld/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MSMPISDK" version="7.1.12437.25" targetFramework="native" />
+</packages>

--- a/CSharp/ArticleProjects/MultiInstanceTasks/MultiInstanceTasks.sln
+++ b/CSharp/ArticleProjects/MultiInstanceTasks/MultiInstanceTasks.sln
@@ -1,26 +1,46 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MultiInstanceTasks", "MultiInstanceTasks.csproj", "{55B3E0CC-7D1E-42F3-B1C2-CB21DF37DE1B}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Azure.Batch.Samples.Common", "..\..\Common\Microsoft.Azure.Batch.Samples.Common.csproj", "{612B170A-1697-4C40-BD57-26A6C8AC6534}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "MPIHelloWorld", "MPIHelloWorld\MPIHelloWorld.vcxproj", "{72607067-3187-45A5-9286-A8E6A60533FD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{55B3E0CC-7D1E-42F3-B1C2-CB21DF37DE1B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{55B3E0CC-7D1E-42F3-B1C2-CB21DF37DE1B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{55B3E0CC-7D1E-42F3-B1C2-CB21DF37DE1B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{55B3E0CC-7D1E-42F3-B1C2-CB21DF37DE1B}.Debug|x64.Build.0 = Debug|Any CPU
 		{55B3E0CC-7D1E-42F3-B1C2-CB21DF37DE1B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{55B3E0CC-7D1E-42F3-B1C2-CB21DF37DE1B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{55B3E0CC-7D1E-42F3-B1C2-CB21DF37DE1B}.Release|x64.ActiveCfg = Release|Any CPU
+		{55B3E0CC-7D1E-42F3-B1C2-CB21DF37DE1B}.Release|x64.Build.0 = Release|Any CPU
 		{612B170A-1697-4C40-BD57-26A6C8AC6534}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{612B170A-1697-4C40-BD57-26A6C8AC6534}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{612B170A-1697-4C40-BD57-26A6C8AC6534}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{612B170A-1697-4C40-BD57-26A6C8AC6534}.Debug|x64.Build.0 = Debug|Any CPU
 		{612B170A-1697-4C40-BD57-26A6C8AC6534}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{612B170A-1697-4C40-BD57-26A6C8AC6534}.Release|Any CPU.Build.0 = Release|Any CPU
+		{612B170A-1697-4C40-BD57-26A6C8AC6534}.Release|x64.ActiveCfg = Release|Any CPU
+		{612B170A-1697-4C40-BD57-26A6C8AC6534}.Release|x64.Build.0 = Release|Any CPU
+		{72607067-3187-45A5-9286-A8E6A60533FD}.Debug|Any CPU.ActiveCfg = Release|x64
+		{72607067-3187-45A5-9286-A8E6A60533FD}.Debug|Any CPU.Build.0 = Release|x64
+		{72607067-3187-45A5-9286-A8E6A60533FD}.Debug|x64.ActiveCfg = Release|x64
+		{72607067-3187-45A5-9286-A8E6A60533FD}.Debug|x64.Build.0 = Release|x64
+		{72607067-3187-45A5-9286-A8E6A60533FD}.Release|Any CPU.ActiveCfg = Release|x64
+		{72607067-3187-45A5-9286-A8E6A60533FD}.Release|Any CPU.Build.0 = Release|x64
+		{72607067-3187-45A5-9286-A8E6A60533FD}.Release|x64.ActiveCfg = Release|x64
+		{72607067-3187-45A5-9286-A8E6A60533FD}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This is to address this issue: https://github.com/Azure/azure-batch-samples/issues/187

I've added the MPI .vcxproj to the multi-instance sample .sln.
I've replaced the references to the MPI env variables with references to a NuGet package so the CI machine and devs downloading the sample can just build it without installing the MPI SDK.
The article tells the user to build the MPI exe in the Release config to avoid needing extra dependencies like msvcp140d.dll.  I decided to just remove the Debug config from the .vcxproj as a result, so even if you build the solution in the Debug config, you're getting the Release config of the .vcxproj.